### PR TITLE
RavenDB-5253: Removing allowNoIndexesOrPrimaryKeys option as it break…

### DIFF
--- a/src/Voron/Data/RootObjectType.cs
+++ b/src/Voron/Data/RootObjectType.cs
@@ -7,5 +7,6 @@
         EmbeddedFixedSizeTree = 2,
         FixedSizeTree = 3,
         PrefixTree = 4,
+        Table = 5,
     }
 }

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -173,6 +173,8 @@ namespace Voron.Data.Tables
 
         public long Update(long id, TableValueBuilder builder)
         {
+            // The ids returned from this function MUST NOT be stored outside of the transaction.
+            // These are merely for manipulation within the same transaction, and WILL CHANGE afterwards.
             int size = builder.Size;
 
             // first, try to fit in place, either in small or large sections
@@ -314,8 +316,11 @@ namespace Voron.Data.Tables
             }
         }
 
+
         public long Insert(TableValueBuilder builder)
         {
+            // The ids returned from this function MUST NOT be stored outside of the transaction.
+            // These are merely for manipulation within the same transaction, and WILL CHANGE afterwards.
             var stats = (TableSchemaStats*)_tableTree.DirectAdd(TableSchema.Stats, sizeof(TableSchemaStats));
             NumberOfEntries++;
             stats->NumberOfEntries = NumberOfEntries;
@@ -645,6 +650,8 @@ namespace Voron.Data.Tables
 
         public long Set(TableValueBuilder builder)
         {
+            // The ids returned from this function MUST NOT be stored outside of the transaction.
+            // These are merely for manipulation within the same transaction, and WILL CHANGE afterwards.
             int size;
             var read = builder.Read(_schema.Key.StartIndex, out size);
 

--- a/src/Voron/Data/Tables/TableValueBuilder.cs
+++ b/src/Voron/Data/Tables/TableValueBuilder.cs
@@ -29,14 +29,24 @@ namespace Voron.Data.Tables
             Add(slice.Content.Ptr, slice.Size);
         }
 
-        public void Add(ulong* ptr)
+        public void Add(ulong value)
         {
-            Add((byte*)ptr, sizeof(ulong));
+            Add((byte*)&value, sizeof(ulong));
         }
 
-        public void Add(long* ptr)
+        public void Add(long value)
         {
-            Add((byte*)ptr, sizeof(long));
+            Add((byte*)&value, sizeof(long));
+        }
+
+        public void Add(int value)
+        {
+            Add((byte*)&value, sizeof(int));
+        }
+
+        public void Add(uint value)
+        {
+            Add((byte*)&value, sizeof(uint));
         }
 
         public void Add(byte* ptr, int size)


### PR DESCRIPTION
…s table encapsulation.

Also added warnings not to store indexes returned from Table's Insert/Update/Set methods, created new RootObjectType for Table nodes, and changed TableValueBuilder to be easier to use
