### PR TITLE
RavenDB-5253: Removing allowNoIndexesOrPrimaryKeys option as it break…

### DIFF
--- a/src/Raven.Server/Documents/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/SubscriptionStorage.cs
@@ -104,11 +104,11 @@ namespace Raven.Server.Documents
 
                 table.Insert(new TableValueBuilder
                 {
-                    &bigEndianId,
+                    bigEndianId,
                     {criteria.BasePointer, criteria.Size},
-                    &ackEtag,
-                    &timeOfSendingLastBatch,
-                    &timeOfLastClientActivity
+                    ackEtag,
+                    timeOfSendingLastBatch,
+                    timeOfLastClientActivity
                 });
                 tx.Commit();
                 if (_logger.IsInfoEnabled)


### PR DESCRIPTION
…s table encapsulation.

Fixed problem in previous commit. Functions removed were being used elsewhere. This was the only occurence.
